### PR TITLE
Get the modulus used in SuperstripArbiter

### DIFF
--- a/AMSimulation/interface/SuperstripArbiter.h
+++ b/AMSimulation/interface/SuperstripArbiter.h
@@ -29,6 +29,10 @@ class SuperstripArbiter {
 
     unsigned nsuperstripsPerLayer() const { return nsuperstripsPerLayer_; }
 
+    unsigned nx() const;
+
+    unsigned nz() const;
+
     bool useGlobalCoord() const { return useGlobalCoord_; }
 
     // Debug

--- a/AMSimulation/src/PatternGenerator.cc
+++ b/AMSimulation/src/PatternGenerator.cc
@@ -224,6 +224,8 @@ int PatternGenerator::writePatterns(TString out) {
     *(writer.pb_count)      = coverage_count_;
     *(writer.pb_tower)      = po_.tower;
     *(writer.pb_superstrip) = po_.superstrip;
+    *(writer.pb_superstrip_nx) = arbiter_->nx();
+    *(writer.pb_superstrip_nz) = arbiter_->nz();
     writer.fillPatternBankInfo();
 
     // _________________________________________________________________________

--- a/AMSimulation/src/SuperstripArbiter.cc
+++ b/AMSimulation/src/SuperstripArbiter.cc
@@ -374,6 +374,50 @@ unsigned SuperstripArbiter::superstripFountain(unsigned moduleId, float r, float
 }
 
 // _____________________________________________________________________________
+unsigned SuperstripArbiter::nx() const {
+    unsigned nx = 0;
+    switch (sstype_) {
+        case SuperstripType::FIXEDWIDTH:
+            nx = MAX_NSTRIPS / fixedwidth_nstrips_;
+            break;
+
+        case SuperstripType::PROJECTIVE:
+            nx = projective_max_nx_;
+            break;
+
+        case SuperstripType::FOUNTAIN:
+            nx = fountain_max_nx_;
+            break;
+
+        default:
+            break;
+    }
+    return nx;
+}
+
+unsigned SuperstripArbiter::nz() const {
+    unsigned nz = 0;
+    switch (sstype_) {
+        case SuperstripType::FIXEDWIDTH:
+            nz = fixedwidth_nz_;
+            break;
+
+        case SuperstripType::PROJECTIVE:
+            nz = projective_nz_;
+            break;
+
+        case SuperstripType::FOUNTAIN:
+            nz = fountain_nz_;
+            break;
+
+        default:
+            break;
+    }
+    return nz;
+}
+
+
+// _____________________________________________________________________________
 void SuperstripArbiter::print() {
     switch (sstype_) {
     case SuperstripType::FIXEDWIDTH:

--- a/AMSimulationIO/interface/PatternBankReader.h
+++ b/AMSimulationIO/interface/PatternBankReader.h
@@ -22,7 +22,8 @@ class PatternBankReader {
 
     int init(TString src);
 
-    void getPatternBankInfo(float& coverage, unsigned& count, unsigned& tower, std::string& superstrip);
+    void getPatternBankInfo(float& coverage, unsigned& count, unsigned& tower, std::string& superstrip,
+                            unsigned& superstrip_nx, unsigned& superstrip_nz);
     void getPatternInvPt(Long64_t entry, float& invPt_mean);
 
     Int_t getPattern(Long64_t entry) { return ttree->GetEntry(entry); }
@@ -44,6 +45,8 @@ class PatternBankReader {
     unsigned                       pb_count;
     unsigned                       pb_tower;
     std::string *                  pb_superstrip;
+    unsigned                       pb_superstrip_nx;
+    unsigned                       pb_superstrip_nz;
 
     // Pattern bank
     frequency_type                 pb_frequency;
@@ -89,6 +92,8 @@ class PatternBankWriter {
     std::auto_ptr<unsigned>                      pb_count;
     std::auto_ptr<unsigned>                      pb_tower;
     std::auto_ptr<std::string>                   pb_superstrip;
+    std::auto_ptr<unsigned>                      pb_superstrip_nx;
+    std::auto_ptr<unsigned>                      pb_superstrip_nz;
 
     // Pattern bank
     std::auto_ptr<frequency_type>                pb_frequency;

--- a/AMSimulationIO/src/PatternBankReader.cc
+++ b/AMSimulationIO/src/PatternBankReader.cc
@@ -19,6 +19,8 @@ PatternBankReader::PatternBankReader(int verbose)
   pb_count          (0),
   pb_tower          (0),
   pb_superstrip     (0),
+  pb_superstrip_nx  (0),
+  pb_superstrip_nz  (0),
   //
   pb_frequency      (0),
   pb_superstripIds  (0),
@@ -66,10 +68,12 @@ int PatternBankReader::init(TString src) {
     ttree2 = (TTree*) tfile->Get("patternBankInfo");
     assert(ttree2 != 0);
 
-    ttree2->SetBranchAddress("coverage"    , &pb_coverage);
-    ttree2->SetBranchAddress("count"       , &pb_count);
-    ttree2->SetBranchAddress("tower"       , &pb_tower);
-    ttree2->SetBranchAddress("superstrip"  , &pb_superstrip);
+    ttree2->SetBranchAddress("coverage"     , &pb_coverage);
+    ttree2->SetBranchAddress("count"        , &pb_count);
+    ttree2->SetBranchAddress("tower"        , &pb_tower);
+    ttree2->SetBranchAddress("superstrip"   , &pb_superstrip);
+    ttree2->SetBranchAddress("superstrip_nx", &pb_superstrip_nx);
+    ttree2->SetBranchAddress("superstrip_nz", &pb_superstrip_nz);
 
     ttree = (TTree*) tfile->Get("patternBank");
     assert(ttree != 0);
@@ -80,13 +84,15 @@ int PatternBankReader::init(TString src) {
     return 0;
 }
 
-void PatternBankReader::getPatternBankInfo(float& coverage, unsigned& count, unsigned& tower, std::string& superstrip) {
+void PatternBankReader::getPatternBankInfo(float& coverage, unsigned& count, unsigned& tower, std::string& superstrip, unsigned& superstrip_nx, unsigned& superstrip_nz) {
     ttree2->GetEntry(0);
 
-    coverage   = pb_coverage;
-    count      = pb_count;
-    tower      = pb_tower;
-    superstrip = (*pb_superstrip);
+    coverage      = pb_coverage;
+    count         = pb_count;
+    tower         = pb_tower;
+    superstrip    = (*pb_superstrip);
+    superstrip_nx = pb_superstrip_nx;
+    superstrip_nz = pb_superstrip_nz;
 }
 
 void PatternBankReader::getPatternInvPt(Long64_t entry, float& invPt_mean) {
@@ -111,6 +117,8 @@ PatternBankWriter::PatternBankWriter(int verbose)
   pb_count          (new unsigned(0)),
   pb_tower          (new unsigned(0)),
   pb_superstrip     (new std::string("")),
+  pb_superstrip_nx  (new unsigned(0)),
+  pb_superstrip_nz  (new unsigned(0)),
   //
   pb_frequency      (new frequency_type(0)),
   pb_superstripIds  (new std::vector<superstrip_type>()),
@@ -159,6 +167,8 @@ int PatternBankWriter::init(TString out) {
     ttree2->Branch("count"         , &(*pb_count));
     ttree2->Branch("tower"         , &(*pb_tower));
     ttree2->Branch("superstrip"    , &(*pb_superstrip));
+    ttree2->Branch("superstrip_nx" , &(*pb_superstrip_nx));
+    ttree2->Branch("superstrip_nz" , &(*pb_superstrip_nz));
 
     // Pattern bank
     ttree = new TTree("patternBank", "");


### PR DESCRIPTION
- Modified SuperstripArbiter to get the modulus used in the superstrip definition, i.e. nx, nz
- Insert the superstrip modulus numbers into the pattern banks
